### PR TITLE
Change path of mvn when M2_HOME is set to M2_HOME/bin

### DIFF
--- a/src/main/java/io/ruck/maven/gocd/plugin/MavenTaskExecutor.java
+++ b/src/main/java/io/ruck/maven/gocd/plugin/MavenTaskExecutor.java
@@ -57,7 +57,7 @@ public class MavenTaskExecutor implements TaskExecutor {
         Map<String, String> env = tec.environment().asMap();
 
         if (env.containsKey("M2_HOME")) {
-            command.add(new File(env.get("M2_HOME"), "mvn").getPath());
+            command.add(new File(env.get("M2_HOME")+"/bin", "mvn").getPath());
         } else {
             command.add("mvn");
         }


### PR DESCRIPTION
Maven expects M2_HOME to point to base of Maven installation.  When M2_HOME is set as such and mvn is not in the PATH for the go agent then the plug-in will not find the executable.  If M2_HOME is set to apache-maven-3.3.x/bin then the executable will be found, but Maven will fail because it cannot load its libraries.  This change uses M2_HOME/bin instead of M2_HOME to find the mvn command when the M2_HOME environment variable is set.
